### PR TITLE
Modernize blog style and fix Markdown tables

### DIFF
--- a/generate.py
+++ b/generate.py
@@ -18,7 +18,7 @@ for filename in os.listdir(POSTS_DIR):
     path = os.path.join(POSTS_DIR, filename)
     with open(path, 'r', encoding='utf-8') as f:
         md_text = f.read()
-    html = markdown.markdown(md_text)
+    html = markdown.markdown(md_text, extensions=["extra"])
     title = 'Untitled'
     for line in md_text.splitlines():
         if line.startswith('# '):

--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Zeyu Gao's Blog</title>
-  <link href="https://fonts.googleapis.com/css2?family=Lora:wght@400;700&display=swap" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css2?family=Open+Sans:wght@400;600;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="static/style.css">
 </head>
 <body>

--- a/posts/bond_tokenization_past_present_future.html
+++ b/posts/bond_tokenization_past_present_future.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Bond Tokenization: Past, Present & Future—A Quant's Perspective</title>
-  <link href="https://fonts.googleapis.com/css2?family=Lora:wght@400;700&display=swap" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css2?family=Open+Sans:wght@400;600;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="../static/style.css">
 </head>
 <body>
@@ -44,14 +44,39 @@
 <li><strong>2023</strong>: Early commercial issuances emerged, including corporate bonds with real-time coupon recording and fractional ownership features.</li>
 </ul>
 <h2>Present (2025 snapshot)</h2>
-<p>As of mid-2025, the global market size of tokenised debt is small relative to traditional bonds but shows consistent growth. Analyst estimates put outstanding issuance between USD 4 and 5 billion[^bis2024]. Most transactions involve private placements or structured notes, though the first few public issuances have appeared in Asia and Europe.</p>
+<p>As of mid-2025, the global market size of tokenised debt is small relative to traditional bonds but shows consistent growth. Analyst estimates put outstanding issuance between USD 4 and 5 billion<sup id="fnref:bis2024"><a class="footnote-ref" href="#fn:bis2024">3</a></sup>. Most transactions involve private placements or structured notes, though the first few public issuances have appeared in Asia and Europe.</p>
 <h3>Leading platforms</h3>
-<p>| Platform | Core technology | Notable activity |
-|----------|----------------|-----------------|
-| <strong>HSBC Orion</strong> | Permissioned ledger built on Hyperledger Fabric | Green bond issuance in Hong Kong, 2024[^hsbc2024] |
-| <strong>SBI Digital Asset Holdings</strong> | Tokenisation and custody infrastructure linked to Japanese broker networks | JGB pilot completed in 2025[^sbi2025] |
-| <strong>ASX Synfini</strong> | Australian DLT sandbox with on-chain settlement hooks | Corporate bond trials since 2023[^asx2023] |
-| <strong>SDX</strong> | Swiss exchange with integrated DLT platform | Euro-denominated corporate bonds traded in 2024 |</p>
+<table>
+<thead>
+<tr>
+<th>Platform</th>
+<th>Core technology</th>
+<th>Notable activity</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><strong>HSBC Orion</strong></td>
+<td>Permissioned ledger built on Hyperledger Fabric</td>
+<td>Green bond issuance in Hong Kong, 2024<sup id="fnref:hsbc2024"><a class="footnote-ref" href="#fn:hsbc2024">4</a></sup></td>
+</tr>
+<tr>
+<td><strong>SBI Digital Asset Holdings</strong></td>
+<td>Tokenisation and custody infrastructure linked to Japanese broker networks</td>
+<td>JGB pilot completed in 2025<sup id="fnref:sbi2025"><a class="footnote-ref" href="#fn:sbi2025">5</a></sup></td>
+</tr>
+<tr>
+<td><strong>ASX Synfini</strong></td>
+<td>Australian DLT sandbox with on-chain settlement hooks</td>
+<td>Corporate bond trials since 2023<sup id="fnref:asx2023"><a class="footnote-ref" href="#fn:asx2023">6</a></sup></td>
+</tr>
+<tr>
+<td><strong>SDX</strong></td>
+<td>Swiss exchange with integrated DLT platform</td>
+<td>Euro-denominated corporate bonds traded in 2024</td>
+</tr>
+</tbody>
+</table>
 <p>These platforms emphasise compliance with local securities laws and integrate with existing clearing mechanisms. Liquidity remains limited, with most trades occurring over-the-counter or through dedicated digital asset venues rather than traditional exchanges.</p>
 <h3>Market participants</h3>
 <p>Major financial institutions now operate dedicated tokenisation desks. Banks issue short-term notes for corporate clients, while asset managers experiment with tokenised fund units. Specialist fintech companies provide middleware for identity verification and compliance monitoring.</p>
@@ -60,7 +85,7 @@
 <h3>Tokenised cash integration</h3>
 <p>Stablecoins and wholesale central-bank digital currencies are being tested alongside tokenised bonds to enable atomic delivery-versus-payment. Several central banks in Asia and Europe now operate pilot networks that link tokenised securities to tokenised cash settlement accounts.</p>
 <h3>Regulatory environment</h3>
-<p>Regulators increasingly recognise tokenised securities within existing frameworks. In Europe, MiCA and the anticipated UK Digital Securities Sandbox provide pathways for larger-scale pilots. In APAC, Singapore's Project Guardian unites banks and asset managers to test interoperability and risk management standards[^guardian2024]. The Australian Securities and Investments Commission (ASIC) continues to refine licensing guidance, while Japan's Financial Services Agency supports sandbox testing under existing security-token regulations.</p>
+<p>Regulators increasingly recognise tokenised securities within existing frameworks. In Europe, MiCA and the anticipated UK Digital Securities Sandbox provide pathways for larger-scale pilots. In APAC, Singapore's Project Guardian unites banks and asset managers to test interoperability and risk management standards<sup id="fnref:guardian2024"><a class="footnote-ref" href="#fn:guardian2024">1</a></sup>. The Australian Securities and Investments Commission (ASIC) continues to refine licensing guidance, while Japan's Financial Services Agency supports sandbox testing under existing security-token regulations.</p>
 <h2>Future scenarios</h2>
 <p>To evaluate potential outcomes for bond tokenisation, it is useful to outline three distinct scenarios. All assume ongoing technological progress but differ in the pace of regulatory harmonisation and market adoption.</p>
 <h3>Scenario 1 – Optimistic</h3>
@@ -108,12 +133,29 @@
 <h2>Outlook</h2>
 <p>Bond tokenisation is unlikely to supplant conventional issuance overnight. However, the ability to automate settlement, streamline compliance and enhance transparency promises meaningful efficiency gains. The greatest barriers are currently regulatory coordination and the lack of deep secondary-market liquidity. Quants who incorporate on-chain data and adapt risk tools stand to benefit from early insights as the market evolves. Whether tokenised debt captures 5% or 20% of future issuance depends on ongoing collaboration between issuers, investors and regulators.</p>
 <h2>References</h2>
-<p>[^guardian2024]: MAS "Project Guardian" progress update, 2024.
-[^esma2025]: ESMA digital bond guidance, 2025.
-[^bis2024]: BIS Bulletin "Tokenisation and its implications", 2024.
-[^hsbc2024]: HSBC, tokenised green bond announcement, 2024.
-[^sbi2025]: SBI Digital Asset Holdings update, 2025.
-[^asx2023]: ASX Synfini trial release, 2023.</p>
+<div class="footnote">
+<hr />
+<ol>
+<li id="fn:guardian2024">
+<p>MAS "Project Guardian" progress update, 2024.&#160;<a class="footnote-backref" href="#fnref:guardian2024" title="Jump back to footnote 1 in the text">&#8617;</a></p>
+</li>
+<li id="fn:esma2025">
+<p>ESMA digital bond guidance, 2025.&#160;<a class="footnote-backref" href="#fnref:esma2025" title="Jump back to footnote 2 in the text">&#8617;</a></p>
+</li>
+<li id="fn:bis2024">
+<p>BIS Bulletin "Tokenisation and its implications", 2024.&#160;<a class="footnote-backref" href="#fnref:bis2024" title="Jump back to footnote 3 in the text">&#8617;</a></p>
+</li>
+<li id="fn:hsbc2024">
+<p>HSBC, tokenised green bond announcement, 2024.&#160;<a class="footnote-backref" href="#fnref:hsbc2024" title="Jump back to footnote 4 in the text">&#8617;</a></p>
+</li>
+<li id="fn:sbi2025">
+<p>SBI Digital Asset Holdings update, 2025.&#160;<a class="footnote-backref" href="#fnref:sbi2025" title="Jump back to footnote 5 in the text">&#8617;</a></p>
+</li>
+<li id="fn:asx2023">
+<p>ASX Synfini trial release, 2023.&#160;<a class="footnote-backref" href="#fnref:asx2023" title="Jump back to footnote 6 in the text">&#8617;</a></p>
+</li>
+</ol>
+</div>
   </main>
 </body>
 </html>

--- a/static/style.css
+++ b/static/style.css
@@ -1,43 +1,74 @@
 body {
   margin: 0;
   padding: 0;
-  font-family: 'Lora', serif;
-  background: #000;
-  color: #fff;
-  line-height: 1.6;
+  font-family: 'Open Sans', sans-serif;
+  background: #f5f5f5;
+  color: #333;
+  line-height: 1.7;
 }
+
 header {
   text-align: center;
-  padding: 80px 20px 40px;
+  padding: 60px 20px 40px;
+  background: #fff;
+  box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+  margin-bottom: 30px;
 }
+
 header h1 {
   margin: 0;
-  font-size: 2.8em;
+  font-size: 2.4em;
   font-weight: 700;
 }
+
 header h2 {
-  margin-top: 10px;
-  font-size: 1.2em;
+  margin-top: 8px;
+  font-size: 1em;
   font-weight: normal;
-  color: #ddd;
+  color: #666;
 }
+
 main {
-  max-width: 700px;
+  max-width: 800px;
   margin: auto;
   padding: 20px;
+  background: #fff;
+  box-shadow: 0 0 10px rgba(0,0,0,0.05);
+  border-radius: 4px;
 }
+
 article + article {
   margin-top: 40px;
 }
+
 h3 {
-  font-size: 1.5em;
+  font-size: 1.6em;
   margin-bottom: 10px;
 }
+
 a {
-  color: #fff;
+  color: #0066cc;
   text-decoration: none;
-  border-bottom: 1px solid #888;
+  border-bottom: 1px solid #0066cc;
 }
+
 a:hover {
-  border-color: #fff;
+  border-color: transparent;
+  text-decoration: underline;
+}
+
+table {
+  width: 100%;
+  border-collapse: collapse;
+  margin-bottom: 20px;
+}
+
+th, td {
+  border: 1px solid #ddd;
+  padding: 8px;
+  text-align: left;
+}
+
+th {
+  background: #f0f0f0;
 }

--- a/templates/index_template.html
+++ b/templates/index_template.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Zeyu Gao's Blog</title>
-  <link href="https://fonts.googleapis.com/css2?family=Lora:wght@400;700&display=swap" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css2?family=Open+Sans:wght@400;600;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="static/style.css">
 </head>
 <body>

--- a/templates/post_template.html
+++ b/templates/post_template.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>{title}</title>
-  <link href="https://fonts.googleapis.com/css2?family=Lora:wght@400;700&display=swap" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css2?family=Open+Sans:wght@400;600;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="../static/style.css">
 </head>
 <body>


### PR DESCRIPTION
## Summary
- refresh CSS with lighter theme and table styling
- switch to Open Sans font in templates and generated pages
- enable `markdown` extras so tables render correctly
- regenerate existing HTML post

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`
- `pip install --user -r requirements.txt`
- `python3 generate.py`

------
https://chatgpt.com/codex/tasks/task_e_686a18dc550c832297a7d7b912fa2ef2